### PR TITLE
Adjust home-copia navigation visibility

### DIFF
--- a/home-copia.html
+++ b/home-copia.html
@@ -154,7 +154,7 @@ box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
 <div class="container mx-auto px-4 flex justify-between items-center">
 <a href="#" class="logo text-primary text-2xl">Sant'Alessandro 17</a>
 <!-- Desktop Navigation -->
-<nav class="desktop-nav flex items-center space-x-8">
+<nav class="desktop-nav hidden md:flex items-center space-x-8">
 <a href="#home" class="text-gray-800 hover:text-primary transition-colors" data-i18n="navHome">Home</a>
 <a href="#attractions" class="text-gray-800 hover:text-primary transition-colors" data-i18n="navAttractions">Attrazioni</a>
 <a href="#restaurants" class="text-gray-800 hover:text-primary transition-colors" data-i18n="navRestaurants">Dove Mangiare</a>
@@ -177,7 +177,7 @@ box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
 </div>
 </nav>
 <!-- Mobile Navigation Button -->
-<button id="mobile-nav-button" class="mobile-nav-button w-10 h-10 flex items-center justify-center">
+<button id="mobile-nav-button" class="mobile-nav-button md:hidden w-10 h-10 flex items-center justify-center">
 <div class="hamburger w-6 h-6 flex flex-col justify-between">
 <span class="hamburger-line block w-full h-0.5 bg-gray-800"></span>
 <span class="hamburger-line block w-full h-0.5 bg-gray-800"></span>


### PR DESCRIPTION
## Summary
- hide desktop menu on mobile with Tailwind `hidden` classes
- show hamburger only on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68587ee81cf08325b25012589ea6e3ae